### PR TITLE
Demo3: Use classnames

### DIFF
--- a/demo3PNG/package.json
+++ b/demo3PNG/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.10.4",
     "@mui/base": "^5.0.0-alpha.101",
     "@mui/material": "^5.10.9",
+    "classnames": "^2.3.2",
     "file-saver": "^2.0.5",
     "html-to-image": "^1.10.8",
     "html2canvas": "^1.4.1",

--- a/demo3PNG/src/components/Avatar.module.css
+++ b/demo3PNG/src/components/Avatar.module.css
@@ -1,18 +1,14 @@
 .container {
+  display: block;
+  position: relative;
+}
+
+.normalSize {
   width: 360px;
   height: 360px;
-  display: block;
-  position: relative;
 }
 
-.smallContainer {
-  width: 180px;
-  height: 180px;
-  display: block;
-  position: relative;
-}
-
-.smallContainer {
+.smallSize {
   width: 180px;
   height: 180px;
 }

--- a/demo3PNG/src/components/Avatar.module.css
+++ b/demo3PNG/src/components/Avatar.module.css
@@ -1,14 +1,6 @@
 .container {
-  display: block;
-  position: relative;
-}
-
-.normalSize {
   width: 360px;
   height: 360px;
-}
-
-.smallSize {
-  width: 180px;
-  height: 180px;
+  display: block;
+  position: relative;
 }

--- a/demo3PNG/src/components/Avatar.module.css
+++ b/demo3PNG/src/components/Avatar.module.css
@@ -10,6 +10,8 @@
   height: 180px;
   display: block;
   position: relative;
+}
+
 .smallContainer {
   width: 180px;
   height: 180px;

--- a/demo3PNG/src/components/Avatar.tsx
+++ b/demo3PNG/src/components/Avatar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { LayerName } from "../types";
 import Layer from "./Layer";
 import styles from "./Avatar.module.css";
+import classnames from "classnames";
 
 type AvatarProps = {
   attributes: Record<LayerName, string>;
@@ -12,7 +13,11 @@ type AvatarProps = {
 
 const Avatar = ({ attributes, layers, source, isSmall }: AvatarProps) => {
   return (
-    <div className={[styles.container, isSmall ? styles.smallContainer : null]}>
+    <div className={classnames([
+      styles.container,
+      styles.normalSize,
+      isSmall ? styles.smallSize : null
+    ])}>
       {layers.map((layer) => {
         return attributes[layer] &&
           source[layer] &&

--- a/demo3PNG/src/components/Avatar.tsx
+++ b/demo3PNG/src/components/Avatar.tsx
@@ -8,16 +8,13 @@ type AvatarProps = {
   attributes: Record<LayerName, string>;
   layers: LayerName[];
   source: Record<string, Record<string, any>>;
-  isSmall?: boolean;
   className?: string;
 };
 
-const Avatar = ({ attributes, layers, source, isSmall, className }: AvatarProps) => {
+const Avatar = ({ attributes, layers, source, className }: AvatarProps) => {
   return (
     <div className={classnames([
       styles.container,
-      styles.normalSize,
-      isSmall ? styles.smallSize : null,
       className ? className : null,
     ])}>
       {layers.map((layer) => {

--- a/demo3PNG/src/components/Avatar.tsx
+++ b/demo3PNG/src/components/Avatar.tsx
@@ -9,14 +9,16 @@ type AvatarProps = {
   layers: LayerName[];
   source: Record<string, Record<string, any>>;
   isSmall?: boolean;
+  className?: string;
 };
 
-const Avatar = ({ attributes, layers, source, isSmall }: AvatarProps) => {
+const Avatar = ({ attributes, layers, source, isSmall, className }: AvatarProps) => {
   return (
     <div className={classnames([
       styles.container,
       styles.normalSize,
-      isSmall ? styles.smallSize : null
+      isSmall ? styles.smallSize : null,
+      className ? className : null,
     ])}>
       {layers.map((layer) => {
         return attributes[layer] &&

--- a/demo3PNG/src/components/ShufflePanel.module.css
+++ b/demo3PNG/src/components/ShufflePanel.module.css
@@ -8,3 +8,8 @@
     width: 100%;
     min-height: 400px;
 }
+
+.smallAvatar {
+  width: 180px;
+  height: 180px;
+}

--- a/demo3PNG/src/components/ShufflePanel.tsx
+++ b/demo3PNG/src/components/ShufflePanel.tsx
@@ -28,12 +28,12 @@ const ShufflePanel = () => {
       <Grid container className={styles.batchContainer}>
         {entities.map((entity, idx) => {
           return (
-            <div className="p-2 text-center">
+            <div key={idx} className="p-2 text-center">
               <Avatar
                 source={configs.pngSource}
                 layers={configs.layers}
                 attributes={entity}
-                isSmall
+                className={styles.smallAvatar}
               />
               <Checkbox
                 checked={!!selected[idx]}


### PR DESCRIPTION
变更：
1. 修复.smallContainer样式问题
2. 为Avatar添加props.className支持自定义样式（主要为尺寸）
3. 提升定制样式到使用场景中，保持Avatar独立