### PR TITLE
Demo3: Batch shuffle depends on supply 

### DIFF
--- a/demo3PNG/src/components/PatchPanel.tsx
+++ b/demo3PNG/src/components/PatchPanel.tsx
@@ -50,7 +50,7 @@ const PatchPanel = () => {
           <li key={`section-${layer}`}>
             <ul>
               <ListSubheader>{`${layer.toUpperCase()}`}</ListSubheader>
-              {Object.keys(configs.attributes[layer]).map((layerStyle) => (
+              {(configs.attributes[layer] || []).map((layerStyle) => (
                 <ListItem key={`item-${layer}-${layerStyle}`}>
                   <ListItemButton
                     role={undefined}

--- a/demo3PNG/src/components/ShufflePanel.module.css
+++ b/demo3PNG/src/components/ShufflePanel.module.css
@@ -110,5 +110,6 @@
   font-size: 14px;
   color: rgb(107,114, 128);
   box-sizing: border-box;
-  text-align: center;
+  padding-left: 4px;
+  text-align: left;
 }

--- a/demo3PNG/src/components/ShufflePanel.module.css
+++ b/demo3PNG/src/components/ShufflePanel.module.css
@@ -29,12 +29,13 @@
   flex: 1;
   overflow: scroll;
   width: 100%;
+  /* 100vh - header - border - pageContainer */
   max-height: calc(100vh - 70px - 1px - 52px);
+  border-bottom: 1px solid #eee;
 }
 
 .gridContainer {
   width: 100%;
-  border-bottom: 1px solid #eee;
   display: grid;
   padding: 10px;
   gap: 10px;

--- a/demo3PNG/src/components/ShufflePanel.tsx
+++ b/demo3PNG/src/components/ShufflePanel.tsx
@@ -14,9 +14,9 @@ import { DEFAULT_TOTAL } from "../constants";
 const PAGE_SIZE = 120;
 
 const ShufflePanel = () => {
-  const [inputValue, setInputValue] = useState(1000);
-  const [total, setTotal] = useState(inputValue);
-  const { entities, updateEntity, shuffleEntities } = useBatch(DEFAULT_TOTAL);
+  const [formedTotal, setFormedTotal] = useState(DEFAULT_TOTAL);
+  const [total, setTotal] = useState(formedTotal);
+  const { entities, updateEntity, shuffleEntities } = useBatch(total);
   const [curIdx, setCurIdx] = useState(-1);
   const [curPage, setCurPage] = useState(1);
 
@@ -37,7 +37,7 @@ const ShufflePanel = () => {
   }, [curPage]);
 
   const onUpdate = () => {
-    setTotal(inputValue);
+    setTotal(formedTotal);
   };
 
   const renderTokenList = () => {
@@ -99,12 +99,12 @@ const ShufflePanel = () => {
           size={"small"}
           label="Tokens"
           focused
-          value={inputValue}
-          onChange={(e) => setInputValue(parseInt(e.target.value || 0))}
+          value={formedTotal}
+          onChange={(e) => setFormedTotal(parseInt(e.target.value || 0))}
         />
         <Button
           variant="contained"
-          disabled={inputValue === entities.length}
+          disabled={formedTotal === entities.length}
           onClick={onUpdate}
         >
           Update

--- a/demo3PNG/src/components/ShufflePanel.tsx
+++ b/demo3PNG/src/components/ShufflePanel.tsx
@@ -14,10 +14,17 @@ const PAGE_SIZE = 120;
 const DEFAULT_TOTAL = 1000;
 
 const ShufflePanel = () => {
-  const [total, setTotal] = useState(1000);
+  const [inputValue, setInputValue] = useState(1000);
+  const [total, setTotal] = useState(inputValue);
   const { entities, updateEntity, shuffleEntities } = useBatch(DEFAULT_TOTAL);
   const [curIdx, setCurIdx] = useState(-1);
   const [curPage, setCurPage] = useState(1);
+
+  useEffect(() => {
+    setCurIdx(-1);
+    setCurPage(1);
+    shuffleEntities(total);
+  }, [total]);
 
   const pageCount = useMemo(() => {
     return Math.ceil(entities.length / PAGE_SIZE);
@@ -30,9 +37,7 @@ const ShufflePanel = () => {
   }, [curPage]);
 
   const onUpdate = () => {
-    setCurIdx(-1);
-    setCurPage(1);
-    shuffleEntities(total);
+    setTotal(inputValue);
   };
 
   const renderTokenList = () => {
@@ -94,12 +99,12 @@ const ShufflePanel = () => {
           size={"small"}
           label="Tokens"
           focused
-          value={total}
-          onChange={(e) => setTotal(parseInt(e.target.value || 0))}
+          value={inputValue}
+          onChange={(e) => setInputValue(parseInt(e.target.value || 0))}
         />
         <Button
           variant="contained"
-          disabled={total === entities.length}
+          disabled={inputValue === entities.length}
           onClick={onUpdate}
         >
           Update

--- a/demo3PNG/src/components/ShufflePanel.tsx
+++ b/demo3PNG/src/components/ShufflePanel.tsx
@@ -5,11 +5,12 @@ import Checkbox from "@mui/material/Checkbox";
 import styles from "./ShufflePanel.module.css";
 import useBatch from "../hooks/useBatch";
 import Avatar from "./Avatar";
-import configs from "../configs";
+import configs, { attributes } from "../configs";
 import { Pagination, Stack, TextField } from "@mui/material";
 import classnames from "classnames";
 import React, { useEffect, useMemo, useState } from "react";
 import { DEFAULT_TOTAL } from "../constants";
+import { getSuppliedAttributes } from "../utils";
 
 const PAGE_SIZE = 120;
 
@@ -19,6 +20,11 @@ const ShufflePanel = () => {
   const { entities, updateEntity, shuffleEntities } = useBatch(DEFAULT_TOTAL);
   const [curIdx, setCurIdx] = useState(-1);
   const [curPage, setCurPage] = useState(1);
+
+  useEffect(() => {
+    const suppliedAttributes = getSuppliedAttributes(total);
+    console.log(suppliedAttributes);
+  }, [total]);
 
   useEffect(() => {
     setCurIdx(-1);

--- a/demo3PNG/src/components/ShufflePanel.tsx
+++ b/demo3PNG/src/components/ShufflePanel.tsx
@@ -10,7 +10,6 @@ import { Pagination, Stack, TextField } from "@mui/material";
 import classnames from "classnames";
 import React, { useEffect, useMemo, useState } from "react";
 import { DEFAULT_TOTAL } from "../constants";
-import { getSuppliedAttributes } from "../utils";
 
 const PAGE_SIZE = 120;
 
@@ -20,11 +19,6 @@ const ShufflePanel = () => {
   const { entities, updateEntity, shuffleEntities } = useBatch(DEFAULT_TOTAL);
   const [curIdx, setCurIdx] = useState(-1);
   const [curPage, setCurPage] = useState(1);
-
-  useEffect(() => {
-    const suppliedAttributes = getSuppliedAttributes(total);
-    console.log(suppliedAttributes);
-  }, [total]);
 
   useEffect(() => {
     setCurIdx(-1);

--- a/demo3PNG/src/components/ShufflePanel.tsx
+++ b/demo3PNG/src/components/ShufflePanel.tsx
@@ -9,9 +9,9 @@ import configs from "../configs";
 import { Pagination, Stack, TextField } from "@mui/material";
 import classnames from "classnames";
 import React, { useEffect, useMemo, useState } from "react";
+import { DEFAULT_TOTAL } from "../constants";
 
 const PAGE_SIZE = 120;
-const DEFAULT_TOTAL = 1000;
 
 const ShufflePanel = () => {
   const [inputValue, setInputValue] = useState(1000);

--- a/demo3PNG/src/configs.ts
+++ b/demo3PNG/src/configs.ts
@@ -13,7 +13,9 @@ export const layers = [
   "eyeglass",
 ] as const;
 
-export const attributes: Record<string, Record<string, number>> = {
+type SuppliedAttributes = Record<string, Record<string, number>>;
+
+export const attributes: SuppliedAttributes = {
   ...Object.keys(pngSource).reduce((layerAcc, layerName) => {
     const layerStyles = pngSource[layerName];
     return {

--- a/demo3PNG/src/configs.ts
+++ b/demo3PNG/src/configs.ts
@@ -13,10 +13,6 @@ export const layers = [
   "eyeglass",
 ] as const;
 
-type AttributeName = string;
-type AttributeStyle = string;
-type AttributeCollection = Record<AttributeName, Array<AttributeStyle>>;
-
 export const attributes = {
   // visible attributes
   ...Object.keys(pngSource).reduce((layerAcc, layerName) => {
@@ -25,7 +21,7 @@ export const attributes = {
       ...layerAcc,
       [layerName]: Object.keys(layerStyles),
     };
-  }, {} as AttributeCollection),
+  }, {} as Record<string, Array<string>>),
 
   // invisible attributes
   // ...

--- a/demo3PNG/src/configs.ts
+++ b/demo3PNG/src/configs.ts
@@ -13,21 +13,22 @@ export const layers = [
   "eyeglass",
 ] as const;
 
-type SuppliedAttributes = Record<string, Record<string, number>>;
+type AttributeName = string;
+type AttributeStyle = string;
+type AttributeCollection = Record<AttributeName, Array<AttributeStyle>>;
 
-export const attributes: SuppliedAttributes = {
+export const attributes = {
+  // visible attributes
   ...Object.keys(pngSource).reduce((layerAcc, layerName) => {
     const layerStyles = pngSource[layerName];
     return {
       ...layerAcc,
-      [layerName]: Object.keys(layerStyles).reduce((styleAcc, styleName) => {
-        return {
-          ...styleAcc,
-          [styleName]: 1,
-        };
-      }, {}),
+      [layerName]: Object.keys(layerStyles),
     };
-  }, {}),
+  }, {} as AttributeCollection),
+
+  // invisible attributes
+  // ...
 };
 
 const configs = {

--- a/demo3PNG/src/constants/index.ts
+++ b/demo3PNG/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TOTAL = 1000;

--- a/demo3PNG/src/hooks/useAvatar.ts
+++ b/demo3PNG/src/hooks/useAvatar.ts
@@ -10,7 +10,7 @@ type Action = {
 const initialState = Object.keys(configs.attributes).reduce((acc, attr) => {
   return {
     ...acc,
-    [attr]: Object.keys(configs.attributes[attr])[0],
+    [attr]: configs.attributes[attr][0],
   };
 }, {} as Attributes);
 

--- a/demo3PNG/src/hooks/useBatch.ts
+++ b/demo3PNG/src/hooks/useBatch.ts
@@ -1,7 +1,7 @@
 import { useReducer } from "react";
 import { DEFAULT_TOTAL } from "../constants";
 import { Attributes } from "../types";
-import { shuffle } from "../utils";
+import { batchShuffleWithSupply, shuffle } from "../utils";
 
 type State = Array<Attributes>;
 type Action =
@@ -20,8 +20,7 @@ type Action =
     };
 
 const generateState = (total: number = DEFAULT_TOTAL): State => {
-  // TODO: shuffle based on supply
-  return new Array(total).fill(0).map(() => shuffle());
+  return batchShuffleWithSupply(total);
 };
 
 const reducer = (state: State, action: Action): State => {

--- a/demo3PNG/src/hooks/useBatch.ts
+++ b/demo3PNG/src/hooks/useBatch.ts
@@ -1,4 +1,5 @@
 import { useReducer } from "react";
+import { DEFAULT_TOTAL } from "../constants";
 import { Attributes } from "../types";
 import { shuffle } from "../utils";
 
@@ -17,8 +18,6 @@ type Action =
         total: number;
       };
     };
-
-const DEFAULT_TOTAL = 1000;
 
 const generateState = (total: number = DEFAULT_TOTAL): State => {
   // TODO: shuffle based on supply

--- a/demo3PNG/src/png/index.ts
+++ b/demo3PNG/src/png/index.ts
@@ -5,11 +5,11 @@ export const pngSource = {
     white: require("./skin/white.png"),
   },
   accessory: {
-    none: "",
     earphones: require("./accessory/earphones.png"),
     earring1: require("./accessory/earring1.png"),
     earring2: require("./accessory/earring2.png"),
     earring3: require("./accessory/earring3.png"),
+    none: "",
   },
   eye: {
     cry: require("./eye/cry.png"),
@@ -48,10 +48,10 @@ export const pngSource = {
     shorthairwaved: require("./hair/shorthairwaved.png"),
   },
   eyeglass: {
-    none: "",
     fancy: require("./eyeglass/fancy.png"),
     harry: require("./eyeglass/harry.png"),
     nerd: require("./eyeglass/nerd.png"),
+    none: "",
     old: require("./eyeglass/old.png"),
     rambo: require("./eyeglass/rambo.png"),
   },

--- a/demo3PNG/src/utils/index.ts
+++ b/demo3PNG/src/utils/index.ts
@@ -4,24 +4,6 @@ import JSZip from "jszip";
 import configs from "../configs";
 import { Attributes } from "../types";
 
-export const getSuppliedAttributes = (total: number) => {
-  return Object.keys(configs.attributes).reduce((accAttrs, attrName) => {
-    const attrStyles = configs.attributes[attrName];
-    const len = attrStyles.length;
-    const perSupply = len >= 0 ? Math.floor(total / len) : 0;
-    const modSupply = len >= 0 ? total % len : 0;
-    return {
-      ...accAttrs,
-      [attrName]: attrStyles.reduce((accStyles, styleName, index) => {
-        return {
-          ...accStyles,
-          [styleName]: index === 0 ? perSupply + modSupply : perSupply,
-        };
-      }, {} as Record<string, number>),
-    };
-  }, {} as Record<string, Record<string, number>>);
-};
-
 export const shuffle = () => {
   return Object.keys(configs.attributes).reduce((accAttrs, attrName) => {
     const collection = configs.attributes[attrName];
@@ -52,6 +34,63 @@ export const download = async (attributes: Attributes, ele: HTMLDivElement) => {
   }
 };
 
-export function random<T>(options: T[]): T | undefined {
+function random<T>(options: T[]): T | undefined {
   return options[Math.floor(Math.random() * options.length)];
 }
+
+/**
+ * @param {number} total e.g. 3
+ * @param {Record<string, Array<string>>} attributes e.g. {skin: ['default', 'white']}
+ * @returns {Record<string, Record<string, number>>} e.g. {skin: {default: 2, white: 1}}
+ */
+export const getAttributesWithSupply = (
+  total: number,
+  attributes: Record<string, Array<string>>
+) => {
+  return Object.keys(attributes).reduce((accAttrs, attrName) => {
+    const attrStyles = attributes[attrName];
+    const len = attrStyles.length;
+    const perSupply = len >= 0 ? Math.floor(total / len) : 0;
+    const modSupply = len >= 0 ? total % len : 0;
+    return {
+      ...accAttrs,
+      [attrName]: attrStyles.reduce((accStyles, styleName, index) => {
+        return {
+          ...accStyles,
+          [styleName]: index === 0 ? perSupply + modSupply : perSupply,
+        };
+      }, {} as Record<string, number>),
+    };
+  }, {} as Record<string, Record<string, number>>);
+};
+
+/**
+ * @param {number} total e.g. 3
+ * @param {Record<string, Array<string>>} attributes e.g. {skin: ['default', 'white']}
+ * @returns {Array<Record<string, string>>} e.g. [{skin: 'default'}, {skin: 'white'}, {skin: 'default'}]
+ */
+export const batchShuffle = (
+  total: number,
+  attributes: Record<string, Array<string>>
+): Array<Record<string, string>> => {
+  const suppliedAttributes = getAttributesWithSupply(total, attributes);
+  const entities = new Array(total).fill(0).map((_, index) => {
+    return Object.keys(suppliedAttributes).reduce((acc, attrName) => {
+      const curAttrStyles = suppliedAttributes[attrName];
+      const options = Object.keys(curAttrStyles).filter(
+        (styleName) => curAttrStyles[styleName]
+      );
+
+      const randomStyle = random(options);
+
+      if (randomStyle === undefined) return acc;
+
+      curAttrStyles[randomStyle] -= 1;
+      return {
+        ...acc,
+        [attrName]: randomStyle,
+      };
+    }, {} as Record<string, string>);
+  });
+  return entities;
+};

--- a/demo3PNG/src/utils/index.ts
+++ b/demo3PNG/src/utils/index.ts
@@ -51,3 +51,7 @@ export const download = async (attributes: Attributes, ele: HTMLDivElement) => {
     console.log("Failed to download", e);
   }
 };
+
+export function random<T>(options: T[]): T | undefined {
+  return options[Math.floor(Math.random() * options.length)];
+}

--- a/demo3PNG/src/utils/index.ts
+++ b/demo3PNG/src/utils/index.ts
@@ -52,12 +52,15 @@ export const getAttributesWithSupply = (
     const len = attrStyles.length;
     const perSupply = len >= 0 ? Math.floor(total / len) : 0;
     const modSupply = len >= 0 ? total % len : 0;
+    // 用于添加modSupply
+    const specialStyleName = random(attrStyles);
     return {
       ...accAttrs,
-      [attrName]: attrStyles.reduce((accStyles, styleName, index) => {
+      [attrName]: attrStyles.reduce((accStyles, styleName) => {
         return {
           ...accStyles,
-          [styleName]: index === 0 ? perSupply + modSupply : perSupply,
+          [styleName]:
+            styleName === specialStyleName ? perSupply + modSupply : perSupply,
         };
       }, {} as Record<string, number>),
     };
@@ -69,9 +72,9 @@ export const getAttributesWithSupply = (
  * @param {Record<string, Array<string>>} attributes e.g. {skin: ['default', 'white']}
  * @returns {Array<Record<string, string>>} e.g. [{skin: 'default'}, {skin: 'white'}, {skin: 'default'}]
  */
-export const batchShuffle = (
+export const batchShuffleWithSupply = (
   total: number,
-  attributes: Record<string, Array<string>>
+  attributes: Record<string, Array<string>> = configs.attributes
 ): Array<Record<string, string>> => {
   const suppliedAttributes = getAttributesWithSupply(total, attributes);
   const entities = new Array(total).fill(0).map((_, index) => {

--- a/demo3PNG/src/utils/index.ts
+++ b/demo3PNG/src/utils/index.ts
@@ -4,15 +4,32 @@ import JSZip from "jszip";
 import configs from "../configs";
 import { Attributes } from "../types";
 
-export const shuffle = (): Attributes => {
-  const { pngSource } = configs;
-  return Object.keys(pngSource).reduce((acc, cur) => {
-    const collection = Object.keys(pngSource[cur]);
+export const getSuppliedAttributes = (total: number) => {
+  return Object.keys(configs.attributes).reduce((accAttrs, attrName) => {
+    const attrStyles = configs.attributes[attrName];
+    const len = attrStyles.length;
+    const perSupply = len >= 0 ? Math.floor(total / len) : 0;
+    const modSupply = len >= 0 ? total % len : 0;
     return {
-      ...acc,
-      [cur]: collection[Math.floor(Math.random() * collection.length)],
+      ...accAttrs,
+      [attrName]: attrStyles.reduce((accStyles, styleName, index) => {
+        return {
+          ...accStyles,
+          [styleName]: index === 0 ? perSupply + modSupply : perSupply,
+        };
+      }, {} as Record<string, number>),
     };
-  }, {});
+  }, {} as Record<string, Record<string, number>>);
+};
+
+export const shuffle = () => {
+  return Object.keys(configs.attributes).reduce((accAttrs, attrName) => {
+    const collection = configs.attributes[attrName];
+    return {
+      ...accAttrs,
+      [attrName]: collection[Math.floor(Math.random() * collection.length)],
+    };
+  }, {} as Record<string, string>);
 };
 
 export const download = async (attributes: Attributes, ele: HTMLDivElement) => {


### PR DESCRIPTION
变更内容：
1. 调整配置configs.attributes类型，从Record<string, Record<string, number>>变更为Record<string, Array<string>>，库存动态生成，便于后期修改
2. 优化总量输入框，点击Update按钮后才生效新的总量，并生成对应的tokens
3. 增加批量Shuffle函数，基于库存实现

BTW，目前库存为平均分配模式，暂不支持定向修改